### PR TITLE
Feature/fix broken tests add new feature minimum lines changed

### DIFF
--- a/clojure/spec/gilded_rose/core_spec.clj
+++ b/clojure/spec/gilded_rose/core_spec.clj
@@ -78,7 +78,7 @@
           (if (= name "Sulfuras, Hand Of Ragnaros")
             (= quality 80)
             (<= 0 quality 50)))))
-  (it "normal items degrade in quality after sell-by by 2"
+  (it "normal items degrade in quality after sell-by by 2 till zero"
       (every-call-to-update-quality
         (gr.c/update-current-inventory)
         (fn [{:keys [name quality sell-in]} prev-item]
@@ -86,6 +86,8 @@
               (= name "Backstage passes to a TAFKAL80ETC concert")
               (= name "Aged Brie")
               (not (neg? sell-in))
+              (and (not (pos? (- (:quality prev-item) 2)))
+                   (zero? quality))
               (= (- (:quality prev-item) 2)
                  quality)))))
   (it "sell-in always goes lower and differs by 1"

--- a/clojure/spec/gilded_rose/core_spec.clj
+++ b/clojure/spec/gilded_rose/core_spec.clj
@@ -39,6 +39,15 @@
           (or (< (:quality prev-item)
                  quality)
               (= 50 quality)))))
+  (it "Conjured items quality degrades twice as fast"
+      (every-call-to-update-quality
+        [(gr.c/item "Conjured"
+                    100
+                    231)]
+        (fn [{:keys [sell-in quality]} prev-item]
+          (or (not (neg? sell-in))
+              (= (:quality prev-item)
+                 (+ quality 4))))))
   (it "Backstage passes quality gets better, then goes to zero"
       (every-call-to-update-quality
         [(gr.c/item "Backstage passes to a TAFKAL80ETC concert"

--- a/clojure/src/gilded_rose/core.clj
+++ b/clojure/src/gilded_rose/core.clj
@@ -1,10 +1,28 @@
 (ns gilded-rose.core)
 
+(defn dec-sell-in
+  [{:keys [sell-in] :as item}]
+  (assoc item
+    :sell-in (dec sell-in)))
+
+(defn change-quality
+  [{:keys [sell-in quality] :as item} neg-quality-fn]
+  (assoc item
+    :quality (if (neg? sell-in)
+               (neg-quality-fn quality)
+               quality)))
+
 (defn update-quality [items]
   (map
     (fn[item] (cond
       (and (< (:sell-in item) 0) (= "Backstage passes to a TAFKAL80ETC concert" (:name item)))
         (merge item {:quality 0})
+
+      (= "Conjured" (:name item))
+      (-> item
+          (change-quality #(- % 4))
+          dec-sell-in)
+
       (or (= (:name item) "Aged Brie") (= (:name item) "Backstage passes to a TAFKAL80ETC concert"))
         (if (and (= (:name item) "Backstage passes to a TAFKAL80ETC concert") (>= (:sell-in item) 5) (< (:sell-in item) 10))
           (merge item {:quality (inc (inc (:quality item)))})
@@ -17,10 +35,12 @@
         (if (= "Backstage passes to a TAFKAL80ETC concert" (:name item))
           (merge item {:quality 0})
           (if (or (= "+5 Dexterity Vest" (:name item)) (= "Elixir of the Mongoose" (:name item)))
-            (merge item {:quality (- (:quality item) 2)})
+            (merge item {:quality (max (- (:quality item) 2)
+                                       0)})
             item))
       (or (= "+5 Dexterity Vest" (:name item)) (= "Elixir of the Mongoose" (:name item)))
-        (merge item {:quality (dec (:quality item))})
+        (merge item {:quality (max (dec (:quality item))
+                                   0)})
       :else item))
   (map (fn [item]
       (if (not= "Sulfuras, Hand of Ragnaros" (:name item))


### PR DESCRIPTION
## Motivation

The tests were passing without any changes to the code base. Namely, the following lines from the specification were blatantly false:

```
- The quality of an item is never negative
```

Finally, we needed to add the new feature requested by the keeper of the gilded rose:

```
We have recently signed a supplier of conjured items. This requires an update to our system:

- "Conjured" items degrade in quality twice as fast as normal items
```
## NOTE:

So a _**lot**_ of assumptions were made in creating a solution to our problem for the keeper.
- The first, and arguably biggest, is that the inn uses the clojure code base to operate in their day to day.
- Next is that the system was in fact broken. The specification we were given could be wrong, not the code. There's a chance that with the keeper being so happy for so long, that our changing things to meet spec has now introduced changes to their day to day.
- "Conjured" _items_ are items with a `name` of `Conjured`. Not a type of items. ie., `normal` items and `conjured` items.
- _Twice as fast as normal items_ means 4.
